### PR TITLE
fix php7.4 deprecated feature

### DIFF
--- a/src/ColorDiff.php
+++ b/src/ColorDiff.php
@@ -246,7 +246,7 @@ class ColorDiff {
       $dg = ((($max - $color['g']) / 6) + ($d / 2)) / $d;
       $db = ((($max - $color['b']) / 6) + ($d / 2)) / $d;
 
-      $h = ($color['r'] == $max) ? $db - $dg : ($color['g'] == $max) ? (1.0 / 3.0) + $dr - $db : (2.0 / 3.0) + $dg - $dr;
+      $h = ($color['r'] == $max) ? $db - $dg : (($color['g'] == $max) ? (1.0 / 3.0) + $dr - $db : (2.0 / 3.0) + $dg - $dr);
       if ($h < 0) {
         $h += 1;
       }


### PR DESCRIPTION
Nested ternary operators without explicit parentheses